### PR TITLE
Xcode Cloud Support

### DIFF
--- a/support/run.sh
+++ b/support/run.sh
@@ -242,6 +242,9 @@ function upload() {
     elif [ -n "$BUILT_PRODUCTS_DIR" ] ; then
       framework_search_path=$BUILT_PRODUCTS_DIR
       log "Using BUILT_PRODUCTS_DIR to set framework search path"
+    elif [ -n "$CI_ARCHIVE_PATH" ] ; then
+      framework_search_path=$CI_ARCHIVE_PATH
+      log "Using CI_ARCHIVE_PATH to set framework search path"
     fi
 
     if [ -n "$EMBRACE_FRAMEWORK_SEARCH_DEPTH" ] ; then


### PR DESCRIPTION
Add check for $CI_ARCHIVE_PATH. This allows a `ci_post_xcodebuild.sh` script to call `run.sh` without any other massaging.

Xcode Cloud environment variable reference: https://developer.apple.com/documentation/xcode/environment-variable-reference